### PR TITLE
Fix exporter geometry handling and design option filters

### DIFF
--- a/sess_geometry/revit_exporter.py
+++ b/sess_geometry/revit_exporter.py
@@ -35,9 +35,6 @@ H_MIN_FT, H_MAX_FT = 5.0, 40.0        # высота 1.5–12 м
 THK_MIN_FT, THK_MAX_FT = 0.15/FT_TO_M, 1.0/FT_TO_M  # 0.15–1.0 м
 
 # ===== векторная математика =====
-def _add(p, v): return DB.XYZ(p.X + v.X, p.Y + v.Y, p.Z + v.Z)
-def _sub(a, b): return DB.XYZ(a.X - b.X, a.Y - b.Y, a.Z - b.Z)
-def _mul(v, s): return DB.XYZ(v.X * s, v.Y * s, v.Z * s)
 def _normalize(v):
     try: return v.Normalize()
     except: return v
@@ -189,11 +186,14 @@ def _room_number(r):
         return s or getattr(r,"Number",None)
     except: return getattr(r,"Number",None)
 
-def _collect_rooms(document, boundary_location, levels_map):
+def _collect_rooms(document, boundary_location, levels_map, wanted_pair):
     out=[]; opts=DB.SpatialElementBoundaryOptions(); opts.SpatialElementBoundaryLocation=boundary_location
     fec=DB.FilteredElementCollector(document).OfCategory(DB.BuiltInCategory.OST_Rooms).WhereElementIsNotElementType()
+    doc_key = _doc_key(document)
     for r in fec:
         if not isinstance(r, DB.SpatialElement): continue
+        if not _design_option_ok(r, doc_key, wanted_pair):
+            continue
         outer,inners=_loops_from_boundary(r.GetBoundarySegments(opts))
         if not outer: continue
         area_ft2=float(getattr(r,"Area",0.0)) if hasattr(r,"Area") else None
@@ -203,11 +203,13 @@ def _collect_rooms(document, boundary_location, levels_map):
                           "signed_area_ft2":_signed_area_xy_ft(inn)} for inn in inners]}
         level_id = r.LevelId.IntegerValue if getattr(r,"LevelId",None) else None
         level_name = levels_map.get(level_id,{}).get("name","")
+        outer_signed = loops["outer"]["signed_area_ft2"]
+        poly_area = abs(outer_signed) - sum(abs(h["signed_area_ft2"]) for h in loops["inners"])
         rec={"id":r.Id.IntegerValue,"unique_id":r.UniqueId,
              "number":_room_number(r),"name":_room_name(r),
              "level_id":level_id,"level":level_name,
              "loops":loops,
-             "poly_area_ft2": loops["outer"]["signed_area_ft2"] - sum(abs(h["signed_area_ft2"]) for h in loops["inners"]),
+             "poly_area_ft2": poly_area,
              "area_ft2_param":area_ft2,"area_m2_param": area_ft2*FT2_TO_M2 if area_ft2 is not None else None,
              "params":_collect_all_params(r, document)}
         # back-compat поля
@@ -218,34 +220,55 @@ def _collect_rooms(document, boundary_location, levels_map):
     return out
 
 # ===== bbox/footprint =====
-def _bb_center(el,T=None):
-    bb=el.get_BoundingBox(None); 
-    if not bb: return None
-    pmin=_of_point(T,bb.Min); pmax=_of_point(T,bb.Max)
-    return DB.XYZ((pmin.X+pmax.X)*0.5,(pmin.Y+pmax.Y)*0.5,(pmin.Z+pmax.Z)*0.5)
-def _bb_size(el,T=None):
-    bb=el.get_BoundingBox(None)
-    if not bb: return None
-    pmin=_of_point(T,bb.Min); pmax=_of_point(T,bb.Max)
-    return [abs(pmax.X-pmin.X),abs(pmax.Y-pmin.Y),abs(pmax.Z-pmin.Z)]
-def _bbox_record(el,T=None):
-    bb=el.get_BoundingBox(None); 
-    if not bb: return None
-    pmin=_of_point(T,bb.Min); pmax=_of_point(T,bb.Max)
-    c=DB.XYZ((pmin.X+pmax.X)*0.5,(pmin.Y+pmax.Y)*0.5,(pmin.Z+pmax.Z)*0.5)
-    return {"min_ft":[_roundf(pmin.X,4),_roundf(pmin.Y,4),_roundf(pmin.Z,4)],
-            "max_ft":[_roundf(pmax.X,4),_roundf(pmax.Y,4),_roundf(pmax.Z,4)],
-            "min_m":[_roundf(pmin.X*FT_TO_M,3),_roundf(pmin.Y*FT_TO_M,3),_roundf(pmin.Z*FT_TO_M,3)],
-            "max_m":[_roundf(pmax.X*FT_TO_M,3),_roundf(pmax.Y*FT_TO_M,3),_roundf(pmax.Z*FT_TO_M,3)],
-            "center_ft":[_roundf(c.X,4),_roundf(c.Y,4),_roundf(c.Z,4)],
-            "center_m":[_roundf(c.X*FT_TO_M,3),_roundf(c.Y*FT_TO_M,3),_roundf(c.Z*FT_TO_M,3)]}
-def _rect_footprint(center,x_dir,y_dir,x_len_ft,y_len_ft):
-    if not (center and x_dir and y_dir and x_len_ft and y_len_ft): return None
-    x=_normalize(x_dir); y=_normalize(y_dir)
-    hx=_mul(x,0.5*x_len_ft); hy=_mul(y,0.5*y_len_ft)
-    p1=_add(_add(center,hx),hy); p2=_add(_sub(center,hx),hy)
-    p3=_sub(_sub(center,hx),hy); p4=_sub(_add(center,hx),hy)
-    return [p1,p2,p3,p4,p1]
+def _bbox_min_max(el, T=None):
+    bb = el.get_BoundingBox(None)
+    if not bb:
+        return None, None
+    bb_tr = getattr(bb, "Transform", None)
+    base = bb_tr if isinstance(bb_tr, DB.Transform) else DB.Transform.Identity
+    mins = [float("inf"), float("inf"), float("inf")]
+    maxs = [float("-inf"), float("-inf"), float("-inf")]
+    for xi in (bb.Min.X, bb.Max.X):
+        for yi in (bb.Min.Y, bb.Max.Y):
+            for zi in (bb.Min.Z, bb.Max.Z):
+                loc = DB.XYZ(xi, yi, zi)
+                world = base.OfPoint(loc)
+                host = _of_point(T, world)
+                mins[0] = min(mins[0], host.X)
+                mins[1] = min(mins[1], host.Y)
+                mins[2] = min(mins[2], host.Z)
+                maxs[0] = max(maxs[0], host.X)
+                maxs[1] = max(maxs[1], host.Y)
+                maxs[2] = max(maxs[2], host.Z)
+    if mins[0] == float("inf"):
+        return None, None
+    pmin = DB.XYZ(mins[0], mins[1], mins[2])
+    pmax = DB.XYZ(maxs[0], maxs[1], maxs[2])
+    return pmin, pmax
+
+def _bb_center(el, T=None):
+    pmin, pmax = _bbox_min_max(el, T)
+    if not (pmin and pmax):
+        return None
+    return DB.XYZ((pmin.X + pmax.X) * 0.5, (pmin.Y + pmax.Y) * 0.5, (pmin.Z + pmax.Z) * 0.5)
+
+def _bb_size(el, T=None):
+    pmin, pmax = _bbox_min_max(el, T)
+    if not (pmin and pmax):
+        return None
+    return [abs(pmax.X - pmin.X), abs(pmax.Y - pmin.Y), abs(pmax.Z - pmin.Z)]
+
+def _bbox_record(el, T=None):
+    pmin, pmax = _bbox_min_max(el, T)
+    if not (pmin and pmax):
+        return None
+    c = DB.XYZ((pmin.X + pmax.X) * 0.5, (pmin.Y + pmax.Y) * 0.5, (pmin.Z + pmax.Z) * 0.5)
+    return {"min_ft": [_roundf(pmin.X, 4), _roundf(pmin.Y, 4), _roundf(pmin.Z, 4)],
+            "max_ft": [_roundf(pmax.X, 4), _roundf(pmax.Y, 4), _roundf(pmax.Z, 4)],
+            "min_m": [_roundf(pmin.X * FT_TO_M, 3), _roundf(pmin.Y * FT_TO_M, 3), _roundf(pmin.Z * FT_TO_M, 3)],
+            "max_m": [_roundf(pmax.X * FT_TO_M, 3), _roundf(pmax.Y * FT_TO_M, 3), _roundf(pmax.Z * FT_TO_M, 3)],
+            "center_ft": [_roundf(c.X, 4), _roundf(c.Y, 4), _roundf(c.Z, 4)],
+            "center_m": [_roundf(c.X * FT_TO_M, 3), _roundf(c.Y * FT_TO_M, 3), _roundf(c.Z * FT_TO_M, 3)]}
 def _footprint_record(ring):
     if not ring: return None
     return {"xy_ft":_xy_ft_from_pts(ring),"xy_m":_xy_m_from_pts(ring)}
@@ -285,63 +308,228 @@ def _valid_or_none(v, vmin, vmax):
     except:
         return None
 
-def _door_dims_ft(fi, T):
-    # width
-    w = _len_from_params(fi,
-        ['DOOR_WIDTH','FAMILY_WIDTH_PARAM','WIDTH'],
-        ['Width','Ширина','Ширина проема','Ширина проёма'])
-    if not w:
-        nw,nh=_nominal_from_typename(_type_name(fi)); 
-        w = nw
-    if not _valid_or_none(w, W_MIN_FT, W_MAX_FT):
-        # bbox fallback
-        sz=_bb_size(fi,T); w = (max(sz[0],sz[1]) if sz else None)
-    if not _valid_or_none(w, W_MIN_FT, W_MAX_FT): return None,None,None
-
-    # height
-    h = _len_from_params(fi,
-        ['DOOR_HEIGHT','FAMILY_HEIGHT_PARAM','HEIGHT'],
-        ['Height','Высота','Высота проема','Высота проёма'])
-    if not h:
-        nw,nh=_nominal_from_typename(_type_name(fi)); 
-        h = nh
-    if not _valid_or_none(h, H_MIN_FT, H_MAX_FT):
-        sz=_bb_size(fi,T); h = (sz[2] if sz else None)
-    h = _valid_or_none(h, H_MIN_FT, H_MAX_FT) or H_MIN_FT
-
-    # depth = host thickness
-    thk=None
+def _is_root_instance(fi):
     try:
-        host=getattr(fi,"Host",None)
+        return getattr(fi, "SuperComponent", None) is None
+    except:
+        return True
+
+def _instance_frame(fi, T):
+    origin = _of_point(T, getattr(getattr(fi, "Location", None), "Point", None)) or _bb_center(fi, T) or DB.XYZ.Zero
+    facing = _normalize(_of_vector(T, getattr(fi, "FacingOrientation", None))) or DB.XYZ.BasisY
+    hand = _normalize(_of_vector(T, getattr(fi, "HandOrientation", None)))
+    if not hand and facing:
+        hand = _normalize(_cross(DB.XYZ.BasisZ, facing))
+    up = _normalize(_cross(facing, hand)) or DB.XYZ.BasisZ
+    hand = _normalize(_cross(up, facing)) or DB.XYZ.BasisX
+    frame = DB.Transform.Identity
+    frame.Origin = origin
+    frame.BasisX = hand
+    frame.BasisY = facing
+    frame.BasisZ = up
+    return frame
+
+def _collect_instance_local_points(fi, T, frame):
+    opts = DB.Options()
+    opts.IncludeNonVisibleObjects = True
+    opts.ComputeReferences = False
+    opts.DetailLevel = DB.ViewDetailLevel.Fine
+    geom = fi.get_Geometry(opts)
+    if not geom:
+        return []
+    inv = frame.Inverse
+    pts = []
+
+    def add(world_pt):
+        if not world_pt:
+            return
+        host_pt = _of_point(T, world_pt)
+        pts.append(inv.OfPoint(host_pt))
+
+    def visit(geometry, tr):
+        for g in geometry:
+            if isinstance(g, DB.GeometryInstance):
+                visit(g.GetSymbolGeometry(), tr.Multiply(g.Transform))
+            elif isinstance(g, DB.Solid):
+                if g.Volume <= 1e-8:
+                    continue
+                for face in g.Faces:
+                    mesh = face.Triangulate()
+                    for i in range(mesh.Vertices.Count):
+                        add(tr.OfPoint(mesh.Vertices[i]))
+                for edge in g.Edges:
+                    curve = edge.AsCurve()
+                    add(tr.OfPoint(curve.GetEndPoint(0)))
+                    add(tr.OfPoint(curve.GetEndPoint(1)))
+            elif isinstance(g, DB.Mesh):
+                for i in range(g.Vertices.Count):
+                    add(tr.OfPoint(g.Vertices[i]))
+            elif isinstance(g, DB.Curve):
+                add(tr.OfPoint(g.GetEndPoint(0)))
+                add(tr.OfPoint(g.GetEndPoint(1)))
+            elif isinstance(g, DB.Point):
+                add(tr.OfPoint(g.Coord))
+        if len(pts) > 4000:
+            return
+
+    visit(geom, DB.Transform.Identity)
+    return pts
+
+def _instance_rect_from_geometry(fi, T, frame):
+    pts = _collect_instance_local_points(fi, T, frame)
+    if not pts:
+        return None
+    min_x = min(p.X for p in pts); max_x = max(p.X for p in pts)
+    min_y = min(p.Y for p in pts); max_y = max(p.Y for p in pts)
+    min_z = min(p.Z for p in pts); max_z = max(p.Z for p in pts)
+    center_local = DB.XYZ((min_x + max_x) * 0.5,
+                          (min_y + max_y) * 0.5,
+                          (min_z + max_z) * 0.5)
+    return {
+        "width": max_x - min_x,
+        "depth": max_y - min_y,
+        "height": max_z - min_z,
+        "center_local": center_local,
+        "min_local": DB.XYZ(min_x, min_y, min_z),
+        "max_local": DB.XYZ(max_x, max_y, max_z),
+    }
+
+def _pick_dim(primary, secondary, vmin, vmax, default=None):
+    for value in (primary, secondary, default):
+        if value and vmin <= value <= vmax:
+            return value
+    return None
+
+def _door_nominal_dims(fi):
+    w = _len_from_params(
+        fi,
+        ['DOOR_WIDTH','FAMILY_WIDTH_PARAM','WIDTH'],
+        ['Width','Ширина','Ширина проема','Ширина проёма']
+    )
+    h = _len_from_params(
+        fi,
+        ['DOOR_HEIGHT','FAMILY_HEIGHT_PARAM','HEIGHT'],
+        ['Height','Высота','Высота проема','Высота проёма']
+    )
+    if not (w and h):
+        w_nom, h_nom = _nominal_from_typename(_type_name(fi))
+        w = w or w_nom
+        h = h or h_nom
+    thk = None
+    try:
+        host = getattr(fi, "Host", None)
         if isinstance(host, DB.Wall):
             thk = host.Width
-    except: pass
-    if not _valid_or_none(thk, THK_MIN_FT, THK_MAX_FT):
-        thk = THK_MIN_FT
-    return w, h, thk
+    except:
+        pass
+    return _valid_or_none(w, W_MIN_FT, W_MAX_FT), \
+           _valid_or_none(h, H_MIN_FT, H_MAX_FT), \
+           _valid_or_none(thk, THK_MIN_FT, THK_MAX_FT)
 
-def _window_dims_ft(fi, T):
-    w = _len_from_params(fi,
+def _window_nominal_dims(fi):
+    w = _len_from_params(
+        fi,
         ['WINDOW_WIDTH','FAMILY_WIDTH_PARAM','WIDTH'],
-        ['Width','Ширина'])
-    h = _len_from_params(fi,
+        ['Width','Ширина']
+    )
+    h = _len_from_params(
+        fi,
         ['WINDOW_HEIGHT','FAMILY_HEIGHT_PARAM','HEIGHT'],
-        ['Height','Высота'])
+        ['Height','Высота']
+    )
     if not (w and h):
-        nw,nh=_nominal_from_typename(_type_name(fi)); w=w or nw; h=h or nh
-    if not _valid_or_none(w, W_MIN_FT, W_MAX_FT):
-        sz=_bb_size(fi,T); w = (max(sz[0],sz[1]) if sz else None)
-    if not _valid_or_none(h, H_MIN_FT, H_MAX_FT):
-        sz=_bb_size(fi,T); h = (sz[2] if sz else None)
-    if not _valid_or_none(w, W_MIN_FT, W_MAX_FT): return None,None,None
-    # host thickness
-    thk=None
+        w_nom, h_nom = _nominal_from_typename(_type_name(fi))
+        w = w or w_nom
+        h = h or h_nom
+    thk = None
     try:
-        host=getattr(fi,"Host",None)
-        if isinstance(host, DB.Wall): thk=host.Width
-    except: pass
-    if not _valid_or_none(thk, THK_MIN_FT, THK_MAX_FT): thk=THK_MIN_FT
-    return w,h,thk
+        host = getattr(fi, "Host", None)
+        if isinstance(host, DB.Wall):
+            thk = host.Width
+    except:
+        pass
+    return _valid_or_none(w, W_MIN_FT, W_MAX_FT), \
+           _valid_or_none(h, H_MIN_FT, H_MAX_FT), \
+           _valid_or_none(thk, THK_MIN_FT, THK_MAX_FT)
+
+def _rect_ring_from_frame(frame, width, depth):
+    if not (frame and width and depth):
+        return None
+    hx = 0.5 * width
+    hy = 0.5 * depth
+    pts = [
+        frame.OfPoint(DB.XYZ( hx,  hy, 0.0)),
+        frame.OfPoint(DB.XYZ(-hx,  hy, 0.0)),
+        frame.OfPoint(DB.XYZ(-hx, -hy, 0.0)),
+        frame.OfPoint(DB.XYZ( hx, -hy, 0.0)),
+    ]
+    pts.append(pts[0])
+    return pts
+
+def _door_window_record(kind, fi, sym, sdoc, linkinst, T, hints):
+    frame = _instance_frame(fi, T)
+    geom = _instance_rect_from_geometry(fi, T, frame)
+    width_hint, height_hint, thk_hint = hints
+    width_geom = geom["width"] if geom else None
+    depth_geom = geom["depth"] if geom else None
+    height_geom = geom["height"] if geom else None
+    center_world = frame.OfPoint(geom["center_local"]) if geom else frame.Origin
+
+    width = _pick_dim(width_hint, width_geom, W_MIN_FT, W_MAX_FT)
+    if not width:
+        return None
+    height = _pick_dim(height_hint, height_geom, H_MIN_FT, H_MAX_FT) or H_MIN_FT
+    thickness = _pick_dim(thk_hint, depth_geom, THK_MIN_FT, THK_MAX_FT) or THK_MIN_FT
+
+    fp_ring = _rect_ring_from_frame(frame, width, thickness)
+    footprint = _footprint_record(fp_ring)
+    placement = {
+        "origin_ft": [_roundf(center_world.X, 4), _roundf(center_world.Y, 4), _roundf(center_world.Z, 4)],
+        "origin_m": [_roundf(center_world.X * FT_TO_M, 3),
+                     _roundf(center_world.Y * FT_TO_M, 3),
+                     _roundf(center_world.Z * FT_TO_M, 3)],
+        "hand": [_roundf(frame.BasisX.X, 4), _roundf(frame.BasisX.Y, 4), _roundf(frame.BasisX.Z, 4)],
+        "facing": [_roundf(frame.BasisY.X, 4), _roundf(frame.BasisY.Y, 4), _roundf(frame.BasisY.Z, 4)],
+        "up": [_roundf(frame.BasisZ.X, 4), _roundf(frame.BasisZ.Y, 4), _roundf(frame.BasisZ.Z, 4)]
+    }
+    size_ft = {
+        "width": _roundf(width, 4),
+        "height": _roundf(height, 4),
+        "thickness": _roundf(thickness, 4)
+    }
+    size_m = {
+        "width": _roundf(width * FT_TO_M, 3),
+        "height": _roundf(height * FT_TO_M, 3),
+        "thickness": _roundf(thickness * FT_TO_M, 3)
+    }
+    if geom:
+        placement["local_min_ft"] = [_roundf(geom["min_local"].X, 4),
+                                      _roundf(geom["min_local"].Y, 4),
+                                      _roundf(geom["min_local"].Z, 4)]
+        placement["local_max_ft"] = [_roundf(geom["max_local"].X, 4),
+                                      _roundf(geom["max_local"].Y, 4),
+                                      _roundf(geom["max_local"].Z, 4)]
+
+    rec = {
+        "kind": kind,
+        "id": fi.Id.IntegerValue,
+        "unique_id": getattr(fi, "UniqueId", None),
+        "type_id": sym.Id.IntegerValue,
+        "type_name": _element_typename(fi, sdoc),
+        "bbox": _bbox_record(fi, T),
+        "footprint": footprint,
+        "params": _collect_all_params(fi, sdoc),
+        "placement": placement,
+        "size_ft": size_ft,
+        "size_m": size_m
+    }
+    if linkinst is not None:
+        rec["in_link"] = {
+            "link_instance_id": linkinst.Id.IntegerValue,
+            "link_doc_title": sdoc.Title,
+            "link_doc_full_path": _user_model_path(sdoc)
+        }
+    return rec
 
 def _type_name(fi):
     try:
@@ -373,25 +561,36 @@ def _flatten_params_simple_dict(raw_dict):
 def _gather_glazing_types():
     rows=[]; seen=set()
     for sdoc, _, _ in _docs_sources(doc):
+        doc_key=_doc_key(sdoc)
+        doc_title=getattr(sdoc, "Title", "") or ""
         for fs in DB.FilteredElementCollector(sdoc).OfClass(DB.FamilySymbol).OfCategory(DB.BuiltInCategory.OST_Windows):
-            tname=_element_typename(fs,sdoc); key=("Windows",fs.Id.IntegerValue)
+            tname=_element_typename(fs,sdoc); key=(doc_key,"Windows",fs.Id.IntegerValue)
             if key in seen: continue
             rows.append({"cat":"Windows","type_id":fs.Id.IntegerValue,"type_name":tname,
-                         "family": getattr(getattr(fs,'Family',None),'Name',""), "params_json":_flatten_params_simple_dict(_collect_params_block(fs))})
+                         "family": getattr(getattr(fs,'Family',None),'Name',""),
+                         "params_json":_flatten_params_simple_dict(_collect_params_block(fs)),
+                         "doc_key":doc_key,
+                         "doc_title":doc_title})
             seen.add(key)
         for fs in DB.FilteredElementCollector(sdoc).OfClass(DB.FamilySymbol).OfCategory(DB.BuiltInCategory.OST_CurtainWallPanels):
-            tname=_element_typename(fs,sdoc); key=("Curtain Panels",fs.Id.IntegerValue)
+            tname=_element_typename(fs,sdoc); key=(doc_key,"Curtain Panels",fs.Id.IntegerValue)
             if key in seen: continue
             rows.append({"cat":"Curtain Panels","type_id":fs.Id.IntegerValue,"type_name":tname,
-                         "family": getattr(getattr(fs,'Family',None),'Name',""), "params_json":_flatten_params_simple_dict(_collect_params_block(fs))})
+                         "family": getattr(getattr(fs,'Family',None),'Name',""),
+                         "params_json":_flatten_params_simple_dict(_collect_params_block(fs)),
+                         "doc_key":doc_key,
+                         "doc_title":doc_title})
             seen.add(key)
         for wt in DB.FilteredElementCollector(sdoc).OfClass(DB.WallType):
             try:
                 if getattr(wt,"Kind",None)==DB.WallKind.Curtain:
-                    key=("Curtain Walls",wt.Id.IntegerValue)
+                    key=(doc_key,"Curtain Walls",wt.Id.IntegerValue)
                     if key in seen: continue
                     rows.append({"cat":"Curtain Walls","type_id":wt.Id.IntegerValue,"type_name":wt.Name,
-                                 "family":"WallType","params_json":_flatten_params_simple_dict(_collect_params_block(wt))})
+                                 "family":"WallType",
+                                 "params_json":_flatten_params_simple_dict(_collect_params_block(wt)),
+                                 "doc_key":doc_key,
+                                 "doc_title":doc_title})
                     seen.add(key)
             except: pass
     rows.sort(key=lambda r:(r["cat"],r["type_name"]))
@@ -400,11 +599,16 @@ def _gather_glazing_types():
 def _gather_door_types():
     rows=[]; seen=set()
     for sdoc, _, _ in _docs_sources(doc):
+        doc_key=_doc_key(sdoc)
+        doc_title=getattr(sdoc, "Title", "") or ""
         for fs in DB.FilteredElementCollector(sdoc).OfClass(DB.FamilySymbol).OfCategory(DB.BuiltInCategory.OST_Doors):
-            tname=_element_typename(fs,sdoc); key=("Doors",fs.Id.IntegerValue)
+            tname=_element_typename(fs,sdoc); key=(doc_key,"Doors",fs.Id.IntegerValue)
             if key in seen: continue
             rows.append({"cat":"Doors","type_id":fs.Id.IntegerValue,"type_name":tname,
-                         "family": getattr(getattr(fs,'Family',None),'Name',""), "params_json":_flatten_params_simple_dict(_collect_params_block(fs))})
+                         "family": getattr(getattr(fs,'Family',None),'Name',""),
+                         "params_json":_flatten_params_simple_dict(_collect_params_block(fs)),
+                         "doc_key":doc_key,
+                         "doc_title":doc_title})
             seen.add(key)
     rows.sort(key=lambda r:(r["cat"],r["type_name"]))
     return rows
@@ -418,13 +622,15 @@ class TypePickerForm(Form):
         self.grid.AllowUserToAddRows=False; self.grid.AllowUserToDeleteRows=False
         self.grid.AutoSizeColumnsMode=DataGridViewAutoSizeColumnsMode.AllCells; self.grid.RowHeadersVisible=False
         col_sel=DataGridViewCheckBoxColumn(); col_sel.HeaderText="Select"
+        col_doc=DataGridViewTextBoxColumn(); col_doc.HeaderText="Document"
         col_cat=DataGridViewTextBoxColumn();  col_cat.HeaderText="Category"
         col_typ=DataGridViewTextBoxColumn();  col_typ.HeaderText="Type"
         col_fam=DataGridViewTextBoxColumn();  col_fam.HeaderText="Family"
         col_par=DataGridViewTextBoxColumn();  col_par.HeaderText="TypeParamsJson"; col_par.Width=600
-        self.grid.Columns.Add(col_sel); self.grid.Columns.Add(col_cat); self.grid.Columns.Add(col_typ)
-        self.grid.Columns.Add(col_fam); self.grid.Columns.Add(col_par)
-        for r in rows: self.grid.Rows.Add(False,r["cat"],r["type_name"],r.get("family",""),r.get("params_json",""))
+        self.grid.Columns.Add(col_sel); self.grid.Columns.Add(col_doc); self.grid.Columns.Add(col_cat)
+        self.grid.Columns.Add(col_typ); self.grid.Columns.Add(col_fam); self.grid.Columns.Add(col_par)
+        for r in rows:
+            self.grid.Rows.Add(False, r.get("doc_title",""), r["cat"], r["type_name"], r.get("family",""), r.get("params_json",""))
         panel=FlowLayoutPanel(); panel.FlowDirection=FlowDirection.LeftToRight; panel.Dock=DockStyle.Bottom; panel.Height=48
         btn_all=Button(); btn_all.Text="Select All"; btn_all.Width=100; btn_all.Click+=self._select_all
         btn_clear=Button(); btn_clear.Text="Clear"; btn_clear.Width=100; btn_clear.Click+=self._clear_all
@@ -432,17 +638,24 @@ class TypePickerForm(Form):
         btn_cancel=Button(); btn_cancel.Text="Cancel"; btn_cancel.Width=100; btn_cancel.Click+=self._cancel
         panel.Controls.Add(btn_all); panel.Controls.Add(btn_clear); panel.Controls.Add(btn_ok); panel.Controls.Add(btn_cancel)
         self.Controls.Add(self.grid); self.Controls.Add(panel)
-        self.selected_ids={}; self._row_type_ids=[r["type_id"] for r in rows]; self._row_cats=[r["cat"] for r in rows]
+        self.selected_ids={}
+        self._row_type_ids=[r["type_id"] for r in rows]
+        self._row_cats=[r["cat"] for r in rows]
+        self._row_doc_keys=[r.get("doc_key") for r in rows]
     def _select_all(self,s,a): 
         for i in range(self.grid.Rows.Count): self.grid.Rows[i].Cells[0].Value=True
     def _clear_all(self,s,a): 
         for i in range(self.grid.Rows.Count): self.grid.Rows[i].Cells[0].Value=False
     def _ok(self,s,a):
-        out={}; 
+        out={};
         for i in range(self.grid.Rows.Count):
             if bool(self.grid.Rows[i].Cells[0].Value):
-                cat=str(self.grid.Rows[i].Cells[1].Value or self._row_cats[i]); tid=int(self._row_type_ids[i])
-                out.setdefault(cat,set()).add(tid)
+                cat=self._row_cats[i]
+                doc_key=self._row_doc_keys[i]
+                tid=int(self._row_type_ids[i])
+                if not doc_key:
+                    continue
+                out.setdefault(cat, {}).setdefault(doc_key, set()).add(tid)
         self.selected_ids=out; self.DialogResult=DialogResult.OK; self.Close()
     def _cancel(self,s,a): self.DialogResult=DialogResult.Cancel; self.Close()
 
@@ -506,29 +719,42 @@ class MainExportForm(Form):
         text=self.cmb_do.SelectedItem
         return self._design_option_map.get(text,(None,None))
 
+    @staticmethod
+    def _has_any_selection(sel_dict):
+        if not isinstance(sel_dict, dict):
+            return False
+        for doc_map in sel_dict.values():
+            if isinstance(doc_map, dict):
+                for ids in doc_map.values():
+                    if ids:
+                        return True
+            elif doc_map:
+                return True
+        return False
+
     def _pick_glazing(self,s,a):
         rows=_gather_glazing_types(); dlg=TypePickerForm(rows,"Выбор типов остекления")
         if dlg.ShowDialog()==DialogResult.OK:
             self.sel_glazing=dlg.selected_ids or {}
-            ok=any(len(s)>0 for s in self.sel_glazing.values()); self.lbl_glaz.Text="✔" if ok else "✖"; self.lbl_glaz.ForeColor=Color.Green if ok else Color.Red
+            ok=self._has_any_selection(self.sel_glazing); self.lbl_glaz.Text="✔" if ok else "✖"; self.lbl_glaz.ForeColor=Color.Green if ok else Color.Red
 
     def _pick_doors(self,s,a):
         rows=_gather_door_types(); dlg=TypePickerForm(rows,"Выбор типов дверей")
         if dlg.ShowDialog()==DialogResult.OK:
             self.sel_doors=dlg.selected_ids or {}
-            ok=any(len(s)>0 for s in self.sel_doors.values()); self.lbl_doors.Text="✔" if ok else "✖"; self.lbl_doors.ForeColor=Color.Green if ok else Color.Red
+            ok=self._has_any_selection(self.sel_doors); self.lbl_doors.Text="✔" if ok else "✖"; self.lbl_doors.ForeColor=Color.Green if ok else Color.Red
 
     def _do_export(self,s,a):
-        if self.cb_glaz.Checked and not any(self.sel_glazing.values()):
+        if self.cb_glaz.Checked and not self._has_any_selection(self.sel_glazing):
             TaskDialog.Show("Export","Выберите типы остекления."); return
-        if self.cb_doors.Checked and not any(self.sel_doors.values()):
+        if self.cb_doors.Checked and not self._has_any_selection(self.sel_doors):
             TaskDialog.Show("Export","Выберите типы дверей."); return
         levels_map=self.levels_map
         levels_list=[{"id":k,"name":v["name"],
                       "elevation_ft":round(v["elevation_ft"],4),
                       "elevation_m": round(v["elevation_m"],3)} for k,v in sorted(levels_map.items(), key=lambda kv: kv[1]["elevation_ft"])]
-        rooms=_collect_rooms(doc, DB.SpatialElementBoundaryLocation.Finish, levels_map) if self.cb_rooms.Checked else []
         pair=self._selected_design_option_pair()
+        rooms=_collect_rooms(doc, DB.SpatialElementBoundaryLocation.Finish, levels_map, pair) if self.cb_rooms.Checked else []
         glazing={"windows":[], "curtain_panels":[], "curtain_walls":[]} if self.cb_glaz.Checked else {"windows":[], "curtain_panels":[], "curtain_walls":[]}
         doors=[]
         if self.cb_glaz.Checked: glazing=_export_glazing(self.sel_glazing, pair)
@@ -562,33 +788,28 @@ def _design_option_ok(el, sdoc_key, wanted_pair):
 # ===== экспорт остекления/дверей =====
 def _export_glazing(sel_glazing, wanted_pair):
     out={"windows":[], "curtain_panels":[], "curtain_walls":[]}
-    win_ids=set(sel_glazing.get("Windows",set())); pan_ids=set(sel_glazing.get("Curtain Panels",set()))
-    cw_ids=set(sel_glazing.get("Curtain Walls",set()))
+    win_map=sel_glazing.get("Windows",{}) if isinstance(sel_glazing, dict) else {}
+    pan_map=sel_glazing.get("Curtain Panels",{}) if isinstance(sel_glazing, dict) else {}
+    cw_map=sel_glazing.get("Curtain Walls",{}) if isinstance(sel_glazing, dict) else {}
     for sdoc,linkinst,T in _docs_sources(doc):
         sdoc_key=_doc_key(sdoc)
+        win_ids=set(win_map.get(sdoc_key, set()))
+        pan_ids=set(pan_map.get(sdoc_key, set()))
+        cw_ids=set(cw_map.get(sdoc_key, set()))
         # Windows
         if win_ids:
             col=DB.FilteredElementCollector(sdoc).OfCategory(DB.BuiltInCategory.OST_Windows).WhereElementIsNotElementType()
             for fi in col:
                 try:
                     if not isinstance(fi, DB.FamilyInstance): continue
+                    if not _is_root_instance(fi):
+                        continue
                     if not _design_option_ok(fi,sdoc_key,wanted_pair): continue
                     sym=fi.Symbol
                     if not sym or sym.Id.IntegerValue not in win_ids: continue
-                    # размеры строго из параметров/номиналов (bbox только на крайний случай)
-                    w,h,thk=_window_dims_ft(fi,T)
-                    if not w: continue
-                    center=_of_point(T, getattr(getattr(fi,"Location",None),"Point", None)) or _bb_center(fi,T)
-                    facing=_of_vector(T, getattr(fi,"FacingOrientation",None))
-                    hand=_of_vector(T, getattr(fi,"HandOrientation",None)) or (_cross(DB.XYZ.BasisZ,facing) if facing else None)
-                    fp_ring=_rect_footprint(center, hand, facing, w, thk) if (center and hand and facing) else None
-                    footprint=_footprint_record(fp_ring)
-                    rec={"kind":"window","id":fi.Id.IntegerValue,"unique_id":getattr(fi,"UniqueId",None),
-                         "type_id":sym.Id.IntegerValue,"type_name":_element_typename(fi,sdoc),
-                         "bbox":_bbox_record(fi,T),"footprint":footprint,"params":_collect_all_params(fi,sdoc)}
-                    if linkinst is not None:
-                        rec["in_link"]={"link_instance_id":linkinst.Id.IntegerValue,"link_doc_title":sdoc.Title,"link_doc_full_path":_user_model_path(sdoc)}
-                    out["windows"].append(rec)
+                    record=_door_window_record("window", fi, sym, sdoc, linkinst, T, _window_nominal_dims(fi))
+                    if record:
+                        out["windows"].append(record)
                 except Exception as ex:
                     logger.warn("Window export issue: {}".format(ex))
         # Panels (только в elements, в openings не тащим)
@@ -597,6 +818,8 @@ def _export_glazing(sel_glazing, wanted_pair):
             for el in col:
                 try:
                     if not isinstance(el, DB.FamilyInstance): continue
+                    if not _is_root_instance(el):
+                        continue
                     if not _design_option_ok(el,sdoc_key,wanted_pair): continue
                     sym=el.Symbol
                     if not sym or sym.Id.IntegerValue not in pan_ids: continue
@@ -628,30 +851,25 @@ def _export_glazing(sel_glazing, wanted_pair):
     return out
 
 def _export_doors(sel_doors, wanted_pair):
-    door_ids=set(sel_doors.get("Doors",set())); res=[]
-    if not door_ids: return res
+    door_map=sel_doors.get("Doors",{}) if isinstance(sel_doors, dict) else {}
+    res=[]
     for sdoc,linkinst,T in _docs_sources(doc):
         sdoc_key=_doc_key(sdoc)
+        door_ids=set(door_map.get(sdoc_key, set()))
+        if not door_ids:
+            continue
         col=DB.FilteredElementCollector(sdoc).OfCategory(DB.BuiltInCategory.OST_Doors).WhereElementIsNotElementType()
         for fi in col:
             try:
                 if not isinstance(fi, DB.FamilyInstance): continue
+                if not _is_root_instance(fi):
+                    continue
                 if not _design_option_ok(fi,sdoc_key,wanted_pair): continue
                 sym=fi.Symbol
                 if not sym or sym.Id.IntegerValue not in door_ids: continue
-                w,h,thk=_door_dims_ft(fi,T)
-                if not w: continue
-                center=_of_point(T, getattr(getattr(fi,"Location",None),"Point", None)) or _bb_center(fi,T)
-                facing=_of_vector(T, getattr(fi,"FacingOrientation",None))
-                hand=_of_vector(T, getattr(fi,"HandOrientation",None)) or (_cross(DB.XYZ.BasisZ,facing) if facing else None)
-                fp_ring=_rect_footprint(center, hand, facing, w, thk) if (center and hand and facing) else None
-                footprint=_footprint_record(fp_ring)
-                rec={"kind":"door","id":fi.Id.IntegerValue,"unique_id":getattr(fi,"UniqueId",None),
-                     "type_id":sym.Id.IntegerValue,"type_name":_element_typename(fi,sdoc),
-                     "bbox":_bbox_record(fi,T),"footprint":footprint,"params":_collect_all_params(fi,sdoc)}
-                if linkinst is not None:
-                    rec["in_link"]={"link_instance_id":linkinst.Id.IntegerValue,"link_doc_title":sdoc.Title,"link_doc_full_path":_user_model_path(sdoc)}
-                res.append(rec)
+                record=_door_window_record("door", fi, sym, sdoc, linkinst, T, _door_nominal_dims(fi))
+                if record:
+                    res.append(record)
             except Exception as ex:
                 logger.warn("Door export issue: {}".format(ex))
     return res


### PR DESCRIPTION
## Summary
- compute door and window placement from oriented instance geometry, avoiding oversized footprints and skipping nested components
- keep selections and exports scoped by document, improve design-option filtering, and ensure room areas use positive boundaries
- make bounding-box transformations rotation-safe when links are involved

## Testing
- python -m compileall sess_geometry/revit_exporter.py

------
https://chatgpt.com/codex/tasks/task_e_68cbca04f6f48327a2a01c6e45a84c84